### PR TITLE
Fix problem with to_ai for nil data

### DIFF
--- a/lib/gs1/record.rb
+++ b/lib/gs1/record.rb
@@ -43,6 +43,8 @@ module GS1
     end
 
     def to_ai
+      return unless to_s
+
       ai + to_s
     end
 

--- a/spec/gs1/record_spec.rb
+++ b/spec/gs1/record_spec.rb
@@ -52,13 +52,21 @@ RSpec.describe GS1::Record do
   describe '#to_ai' do
     subject { record.to_ai }
 
+    let(:ai) { 'AI' }
+    let(:data) { 'DATA' }
+
     before do
-      allow(record).to receive(:ai).and_return('AI')
-      allow(record).to receive(:to_s).and_return('DATA')
+      allow(record).to receive(:ai).and_return(ai)
     end
 
-    it 'concatinates #ai and #data' do
+    it 'concatinates #ai and #to_s' do
       is_expected.to eq('AIDATA')
+    end
+
+    context 'when no data' do
+      let(:data) { nil }
+
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION
Fixes issue with `#to_ai` when `data` is nil for a GS1 record.

```ruby
TypeError:
  no implicit conversion of nil into String
# ./lib/gs1/record.rb:48:in `+'
# ./lib/gs1/record.rb:48:in `to_ai'
# ./spec/gs1/record_spec.rb:53:in `block (3 levels) in <top (required)>'
# ./spec/gs1/record_spec.rb:69:in `block (4 levels) in <top (required)>'
```