### PR TITLE
Allow max variable length when shifting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ cache: bundler
 rvm:
   - 2.3.0
   - 2.5.1
-before_install: gem install bundler -v 1.16.5
+before_install: gem install bundler -v 1.17.3

--- a/gs1.gemspec
+++ b/gs1.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'byebug', '~> 10.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rb-readline', '~> 0.1'

--- a/lib/gs1/barcode/segment.rb
+++ b/lib/gs1/barcode/segment.rb
@@ -99,7 +99,7 @@ module GS1
       def shift_separator_length
         separator_index = data.find_index(separator)
 
-        return unless separator_index && separator_index < record.barcode_max_length
+        return unless separator_index && separator_index <= record.barcode_max_length
 
         shift_fixed_length(separator_index).tap do
           data.shift # Shift separator character

--- a/spec/gs1/barcode/healthcare_spec.rb
+++ b/spec/gs1/barcode/healthcare_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe GS1::Barcode::Healthcare do
         expect(subject.serial_number).to eq(GS1::SerialNumber.new('123123'))
       end
     end
+
+    context "maximum length of serial number + separator" do
+      let(:data) { "01070462606504112101582353425597816838\u001E1721093010184238131" }
+
+      it 'sets all attributes' do
+        expect(subject.gtin).to eq(GS1::GTIN.new('07046260650411'))
+        expect(subject.expiration_date).to eq(GS1::ExpirationDate.new('210930'))
+        expect(subject.batch).to eq(GS1::Batch.new('184238131'))
+        expect(subject.serial_number).to eq(GS1::SerialNumber.new('01582353425597816838'))
+      end
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
Fixes issue with segments that are full lengths and contains a separator.

TP: https://apoexab.tpondemand.com/entity/14249