### PR TITLE
Allow GSIN check digit to be calculated

### DIFF
--- a/lib/gs1/check_digit_calculator.rb
+++ b/lib/gs1/check_digit_calculator.rb
@@ -7,7 +7,7 @@ module GS1
   #
   class CheckDigitCalculator
     MULTIPLIER_ARRAY = [3, 1] * 9
-    VALID_LENGTHS = [7, 11, 12, 13, 17].freeze
+    VALID_LENGTHS = [7, 11, 12, 13, 16, 17].freeze
 
     def initialize(sequence)
       @sequence = sequence

--- a/spec/gs1/check_digit_calculator_spec.rb
+++ b/spec/gs1/check_digit_calculator_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe GS1::CheckDigitCalculator do
       end
     end
 
+    context 'GSIN example' do
+      let(:sequence) { '7350066493304104' }
+
+      it 'calculates correct check digit' do
+        is_expected.to eq('3')
+      end
+    end
+
     context 'SSCC example' do
       let(:sequence) { '87350066493304104' }
 


### PR DESCRIPTION
Adds support to calculate check digit for GSIN number (the length of a GSIN number is 16 without check digit).

Source: https://www.gs1.org/services/how-calculate-check-digit-manually