### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ruby
           bundler-cache: true
 
       - name: Extract Version


### PR DESCRIPTION
Need to use a later version of Ruby where `gem` command supports the `exec` subcommand. Otherwise publishing the gem fails with:

```
ERROR:  While executing gem ... (Gem::CommandLineError)
    Unknown command exec
```