### PR TITLE
Don't run `bundle install` in the release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
-          bundler-cache: true
 
       - name: Extract Version
         id: version


### PR DESCRIPTION
We have an older version of Bundler in `Gemfile.lock` which is not compatible with later versions of Ruby. But we need a later version of Ruby since the `rubygems/release-gem` action uses the `gem exec` command which is fairly new. We cannot update to a later version of Ruby or Bundler due to needing to be compatible with applications running older versions.

```
/opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/gems/3.4.0/gems/bundler-2.2.33/lib/bundler/vendor/thor/lib/thor/error.rb:105:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
```