### PR TITLE
[#34565] Fix NoMethodError in GS1::Barcode::Healthcare#to_s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fix: `@8110' is not allowed as an instance variable name
+- Fix NoMethodError in `GS1::Barcode::Healthcare#to_s`
 
 ## [2.0.2] - 2025-04-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.3] - 2025-04-29
 ### Fixed
 - Fix: `@8110' is not allowed as an instance variable name
 - Fix NoMethodError in `GS1::Barcode::Healthcare#to_s`
@@ -58,8 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix `nil` argument for barcode
 
-[Unreleased]: https://github.com/apoex/gs1/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/apoex/gs1/compare/v2.0.3...HEAD
 
+[2.0.2]: https://github.com/apoex/gs1/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/apoex/gs1/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/apoex/gs1/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/apoex/gs1/compare/v1.1.0...v2.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gs1 (2.0.2)
+    gs1 (2.0.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/gs1/barcode/base.rb
+++ b/lib/gs1/barcode/base.rb
@@ -6,15 +6,15 @@ module GS1
       include Definitions
 
       def initialize(attributes = {}, options = {})
+        @params_order = []
         attribute_validator = options[:attribute_validator] || AttributeValidator.new
         attributes.each do |(name, data)|
           attribute_validator.validate_data(self, name)
           attribute_validator.validate_record(self, name) do |record|
             instance_variable_set("@#{name}", record.new(data))
+            @params_order << name
           end
         end
-
-        @params_order = attributes.to_h.keys
       end
 
       def errors

--- a/lib/gs1/version.rb
+++ b/lib/gs1/version.rb
@@ -1,3 +1,3 @@
 module GS1
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.0.3'.freeze
 end

--- a/spec/gs1/barcode/healthcare_spec.rb
+++ b/spec/gs1/barcode/healthcare_spec.rb
@@ -120,7 +120,9 @@ RSpec.describe GS1::Barcode::Healthcare do
   end
 
   describe '#to_s' do
-    subject { described_class.from_scan(example_scan, separator: separator) }
+    subject(:scanned_barcode) do
+      described_class.from_scan(example_scan, separator: separator)
+    end
 
     let(:separator) { "\u001E" }
 
@@ -189,16 +191,16 @@ RSpec.describe GS1::Barcode::Healthcare do
       let(:rescan) { described_class.from_scan(subject.to_s) }
 
       it 'reproduces the input' do
-        expect(subject.to_s).to eq example_scan
+        expect(scanned_barcode.to_s).to eq example_scan
       end
 
       it 'is reparseable', :aggregate_failures do
         expect { rescan }.not_to raise_error
 
-        expect(rescan.gtin).to eq subject.gtin
-        expect(rescan.batch).to eq subject.batch
-        expect(rescan.expiration_date).to eq subject.expiration_date
-        expect(rescan.serial_number).to eq subject.serial_number
+        expect(rescan.gtin).to eq scanned_barcode.gtin
+        expect(rescan.batch).to eq scanned_barcode.batch
+        expect(rescan.expiration_date).to eq scanned_barcode.expiration_date
+        expect(rescan.serial_number).to eq scanned_barcode.serial_number
       end
     end
 
@@ -206,7 +208,7 @@ RSpec.describe GS1::Barcode::Healthcare do
       let(:example_scan) { '01000000123123131718100310123123123' }
 
       it 'reproduces the input' do
-        expect(subject.to_s).to eq example_scan
+        expect(scanned_barcode.to_s).to eq example_scan
       end
     end
 
@@ -214,7 +216,7 @@ RSpec.describe GS1::Barcode::Healthcare do
       let(:example_scan) { "010000001231231310123123123\u001E17181003" }
 
       it 'reproduces the input' do
-        expect(subject.to_s).to eq example_scan
+        expect(scanned_barcode.to_s).to eq example_scan
       end
     end
 
@@ -222,7 +224,7 @@ RSpec.describe GS1::Barcode::Healthcare do
       let(:example_scan) { '0100000012312313' }
 
       it 'reproduces the input' do
-        expect(subject.to_s(level: GS1::AIDCMarketingLevels::MINIMUM)).to eq example_scan
+        expect(scanned_barcode.to_s(level: GS1::AIDCMarketingLevels::MINIMUM)).to eq example_scan
       end
     end
   end

--- a/spec/gs1/barcode/healthcare_spec.rb
+++ b/spec/gs1/barcode/healthcare_spec.rb
@@ -120,6 +120,8 @@ RSpec.describe GS1::Barcode::Healthcare do
   end
 
   describe '#to_s' do
+    subject { described_class.from_scan(example_scan, separator: separator) }
+
     let(:separator) { "\u001E" }
 
     let(:level) { GS1::AIDCMarketingLevels::ENHANCED }
@@ -186,8 +188,6 @@ RSpec.describe GS1::Barcode::Healthcare do
       let(:example_scan) { "01000000123123131718100310123123123\u001E21123123" }
       let(:rescan) { described_class.from_scan(subject.to_s) }
 
-      subject { described_class.from_scan(example_scan) }
-
       it 'reproduces the input' do
         expect(subject.to_s).to eq example_scan
       end
@@ -205,8 +205,6 @@ RSpec.describe GS1::Barcode::Healthcare do
     context 'when 01000000123123131718100310123123123' do
       let(:example_scan) { '01000000123123131718100310123123123' }
 
-      subject { described_class.from_scan(example_scan) }
-
       it 'reproduces the input' do
         expect(subject.to_s).to eq example_scan
       end
@@ -215,8 +213,6 @@ RSpec.describe GS1::Barcode::Healthcare do
     context "when 010000001231231310123123123\u001E17181003" do
       let(:example_scan) { "010000001231231310123123123\u001E17181003" }
 
-      subject { described_class.from_scan(example_scan) }
-
       it 'reproduces the input' do
         expect(subject.to_s).to eq example_scan
       end
@@ -224,8 +220,6 @@ RSpec.describe GS1::Barcode::Healthcare do
 
     context 'when 0100000012312313' do
       let(:example_scan) { '0100000012312313' }
-
-      subject { described_class.from_scan(example_scan) }
 
       it 'reproduces the input' do
         expect(subject.to_s(level: GS1::AIDCMarketingLevels::MINIMUM)).to eq example_scan

--- a/spec/gs1/barcode/healthcare_spec.rb
+++ b/spec/gs1/barcode/healthcare_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe GS1::Barcode::Healthcare do
         let(:expected_batch_part) { "#{GS1::Batch::AI}#{batch_data}" }
         let(:expected_serial_number_part) { "#{GS1::SerialNumber::AI}#{serial_number_data}" }
 
-        it 'returns all attributes concatinated in same order as params' do
+        it 'returns all attributes concatenated in same order as params' do
           is_expected.to eq(expected_gtin_part +
                             expected_batch_part + separator +
                             expected_expiration_date_part +
@@ -154,7 +154,7 @@ RSpec.describe GS1::Barcode::Healthcare do
               expiration_date: expiration_date_data }
           end
 
-          it 'returns all attributes concatinated in same order as params' do
+          it 'returns all attributes concatenated in same order as params' do
             is_expected.to eq(expected_gtin_part +
                               expected_batch_part + separator +
                               expected_serial_number_part + separator +

--- a/spec/gs1/barcode/healthcare_spec.rb
+++ b/spec/gs1/barcode/healthcare_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe GS1::Barcode::Healthcare do
 
     context 'when 01000000123123131718100310123123123' do
       let(:example_scan) { '01000000123123131718100310123123123' }
-      let(:rescan) { described_class.from_scan(subject.to_s) }
 
       subject { described_class.from_scan(example_scan) }
 
@@ -215,7 +214,6 @@ RSpec.describe GS1::Barcode::Healthcare do
 
     context "when 010000001231231310123123123\u001E17181003" do
       let(:example_scan) { "010000001231231310123123123\u001E17181003" }
-      let(:rescan) { described_class.from_scan(subject.to_s) }
 
       subject { described_class.from_scan(example_scan) }
 
@@ -226,7 +224,6 @@ RSpec.describe GS1::Barcode::Healthcare do
 
     context 'when 0100000012312313' do
       let(:example_scan) { '0100000012312313' }
-      let(:rescan) { described_class.from_scan(subject.to_s) }
 
       subject { described_class.from_scan(example_scan) }
 

--- a/spec/gs1/barcode/healthcare_spec.rb
+++ b/spec/gs1/barcode/healthcare_spec.rb
@@ -227,6 +227,14 @@ RSpec.describe GS1::Barcode::Healthcare do
         expect(scanned_barcode.to_s(level: GS1::AIDCMarketingLevels::MINIMUM)).to eq example_scan
       end
     end
+
+    context 'when the barcode contains ignored element strings' do
+      let(:example_scan) { "0100000000000017101#{separator}11000000211#{separator}17250512" }
+
+      it 'reproduces the input without the ignored element strings' do
+        expect(scanned_barcode.to_s).to eq("0100000000000017101#{separator}211#{separator}17250512")
+      end
+    end
   end
 
   describe '#valid?' do


### PR DESCRIPTION
The fix is to exclude ignored element strings. I recommend to look at each commit separately.